### PR TITLE
Document failed test speedup attempt

### DIFF
--- a/src/test/utils/mocks/mockClock.ts
+++ b/src/test/utils/mocks/mockClock.ts
@@ -18,7 +18,11 @@ export class MockClock extends Clock {
   }
 
   addEvent(config: Phaser.Time.TimerEvent | Phaser.Types.Time.TimerEventConfig): Phaser.Time.TimerEvent {
-    const cfg = { ...config, delay: this.overrideDelay || config.delay};
-    return super.addEvent(cfg);
+    return super.addEvent({
+      delay: 0.01,
+      repeat: 0,
+      startAt: 0,
+      callback: config.callback,
+    });
   }
 }


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

<!-- Summarize what are the changes from a user perspective on the application -->

## Why am I making these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->

<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
Documenting a failed attempt to speed up unit tests by disabling certain timer-based animations during unit tests. These animations include summoning your party Pokemon, the flashing animation from getting hit by a move, and the animation of presenting reward options after a battle.

## Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->
### Before the changes:

![Before Test Changes](https://github.com/user-attachments/assets/7ad2498a-003f-4e57-9b49-363a8b1a9890)

### After the changes:

![After Test Changes](https://github.com/user-attachments/assets/7835f3c0-229e-41ad-be62-5dd1b6b58265)


## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
`npm run test`

## Discussion:

I have tested these changes both on the full tests (screenshots above) and on individual test files.
- Individual test files:
  - It appears that the changes do successfully disable timer-based animations and do speed up individual test files.
  - Unfortunately, this by itself is not that useful because when running an individual test file, most of the time spent is on setup, not on the actual tests.
- Full tests (see above screenshots):
  - Here, it turns out that the changes do not speed up the full tests by much.
  - I believe there are two reasons for this.
  - First, based on the screenshots, the changes significantly increase the amount of time spent on "environment".
  - Second, running the full tests involves running multiple test files in parallel, so when one test file is waiting on an animation, the computer can simply work on a different test file. (Edit: Apparently, this is FALSE, since disabling Pokemon cries does speed up the full tests.)